### PR TITLE
Fix: Persist metadata and download provider priority #118

### DIFF
--- a/go_backend/extension_providers.go
+++ b/go_backend/extension_providers.go
@@ -623,7 +623,9 @@ var metadataProviderPriority []string
 var metadataProviderPriorityMu sync.RWMutex
 func persist(key string, value any) {
 	if store := GetExtensionSettingsStore(); store != nil {
-		_ = store.Set("_system", key, value) // ignore errors for simplicity
+		if err := store.Set("_system", key, value); err != nil {
+			GoLog("[Extension] Failed to persist setting %s: %v\n", key, err)
+		}
 	}
 }
 
@@ -658,7 +660,8 @@ func GetProviderPriority() []string {
 		providerPriority = loaded
 		GoLog("[Extension] Loaded provider priority: %v\n", loaded)
 	} else {
-		return []string{"tidal", "qobuz", "amazon"}
+		providerPriority = []string{"tidal", "qobuz", "amazon"}
+		GoLog("[Extension] Using default provider priority: %v\n", providerPriority)
 	}
 
 	result := make([]string, len(providerPriority))
@@ -697,7 +700,8 @@ func GetMetadataProviderPriority() []string {
 		metadataProviderPriority = loaded
 		GoLog("[Extension] Loaded metadata provider priority: %v\n", loaded)
 	} else {
-		return []string{"deezer", "spotify"}
+		metadataProviderPriority = []string{"deezer", "spotify"}
+		GoLog("[Extension] Using default metadata provider priority: %v\n", metadataProviderPriority)
 	}
 
 	result := make([]string, len(metadataProviderPriority))


### PR DESCRIPTION
This PR fixes #118  an issue where the custom order of metadata and download providers was not being saved app restarts.

Added logic to persist provider priorities to `ExtensionSettingsStore (_system namespace)` and restore them on startup. 

Introduced a  `loadPriorityFromSettings` helper to handle loading cleanly, ensuring code is preserved and minimizing duplication, while maintaining full thread safety.

- Tested on Android Emulator.

https://github.com/user-attachments/assets/69dabb21-54f2-4594-8cb7-9752b0eefd74

