### PR TITLE
fix(ui): resolve "Press back again to exit" not working correctly

### DIFF
--- a/lib/screens/main_shell.dart
+++ b/lib/screens/main_shell.dart
@@ -486,10 +486,11 @@ class _MainShellState extends ConsumerState<MainShell> {
       });
     }
 
-    return BackButtonListener(
-      onBackButtonPressed: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
         _handleBackPress();
-        return true;
       },
       child: Scaffold(
         body: PageView(


### PR DESCRIPTION
### Problem
The "Press back again to exit" snackbar/toast was not appearing, or the back button logic was inconsistent. This was caused by `BackButtonListener` not properly intercepting the system back event in conjunction with `GoRouter` and the current navigation stack.

### Solution
Replaced `BackButtonListener` with the modern **`PopScope`** widget in `MainShell`.

### Changes
- Wrapped the main Scaffold with `PopScope`.
- Set `canPop: false` to ensure we handle the exit logic manually (double-tap to exit).
- Invoked the existing `_handleBackPress()` logic inside `onPopInvokedWithResult`.

This ensures consistent back button handling across Android versions (including predictive back gesture support).