### PR TITLE
Create subfolders for Library Playlists when Folder Organization is By Playlist

### DIFF
--- a/lib/screens/library_tracks_folder_screen.dart
+++ b/lib/screens/library_tracks_folder_screen.dart
@@ -39,6 +39,7 @@ class _LibraryTracksFolderScreenState
 
   bool _isSelectionMode = false;
   final Set<String> _selectedKeys = {};
+  UserPlaylistCollection? playlist;
 
   @override
   void initState() {
@@ -243,7 +244,6 @@ class _LibraryTracksFolderScreenState
     final colorScheme = Theme.of(context).colorScheme;
     ref.watch(localLibraryProvider.select((s) => s.items));
     final localState = ref.read(localLibraryProvider);
-    final UserPlaylistCollection? playlist;
     final List<CollectionTrackEntry> entries;
 
     switch (widget.mode) {
@@ -873,6 +873,7 @@ class _LibraryTracksFolderScreenState
   void _downloadAll(List<Track> tracks) {
     if (tracks.isEmpty) return;
     final settings = ref.read(settingsProvider);
+    final playlistName = widget.mode == LibraryTracksFolderMode.playlist ? playlist?.name ?? context.l10n.collectionPlaylist : null;
     if (settings.askQualityBeforeDownload) {
       DownloadServicePicker.show(
         context,
@@ -885,7 +886,7 @@ class _LibraryTracksFolderScreenState
         onSelect: (quality, service) {
           ref
               .read(downloadQueueProvider.notifier)
-              .addMultipleToQueue(tracks, service, qualityOverride: quality);
+              .addMultipleToQueue(tracks, service, qualityOverride: quality, playlistName: playlistName);
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -899,7 +900,7 @@ class _LibraryTracksFolderScreenState
     } else {
       ref
           .read(downloadQueueProvider.notifier)
-          .addMultipleToQueue(tracks, settings.defaultService);
+          .addMultipleToQueue(tracks, settings.defaultService, playlistName: playlistName);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(context.l10n.snackbarAddedTracksToQueue(tracks.length)),


### PR DESCRIPTION
#217

Summary of changes
- Moved the playlist variable out of build into the component so it is accessible elsewhere (I guess the alternative is to pass it all the way down)
- Used that moved playlist variable to pass the playlistName conditionally if this screen is for a library playlist

Love this project and I hope it's ok if I open more PRs in future. ❤️ 
Also, obviously, happy to change anything here if it looks off or doesn't adhere to xyz :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playlist information handling so playlist names are preserved when downloading tracks and adding items to the playback queue. This ensures consistent labeling of queued downloads across interactive and non-interactive flows, preventing loss of playlist context during download-all and queue operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->