### PR TITLE
Auto-fill playlist name when importing from Spotify

### DIFF
--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -533,7 +533,7 @@ class _PlaylistScreenState extends ConsumerState<PlaylistScreen> {
       tooltip: context.l10n.tooltipAddToPlaylist,
       onPressed: _tracks.isEmpty
           ? null
-          : () => showAddTracksToPlaylistSheet(context, ref, _tracks),
+          : () => showAddTracksToPlaylistSheet(context, ref, _tracks, playlistNamePrefill: widget.playlistName),
     );
   }
 

--- a/lib/widgets/playlist_picker_sheet.dart
+++ b/lib/widgets/playlist_picker_sheet.dart
@@ -20,6 +20,7 @@ Future<void> showAddTracksToPlaylistSheet(
   BuildContext context,
   WidgetRef ref,
   List<Track> tracks,
+  {String? playlistNamePrefill}
 ) async {
   if (tracks.isEmpty) return;
 
@@ -31,15 +32,16 @@ Future<void> showAddTracksToPlaylistSheet(
     showDragHandle: true,
     isScrollControlled: true,
     builder: (sheetContext) {
-      return _PlaylistPickerSheetContent(tracks: tracks);
+      return _PlaylistPickerSheetContent(tracks: tracks, playlistNamePrefill: playlistNamePrefill);
     },
   );
 }
 
 class _PlaylistPickerSheetContent extends ConsumerStatefulWidget {
   final List<Track> tracks;
+  final String? playlistNamePrefill;
 
-  const _PlaylistPickerSheetContent({required this.tracks});
+  const _PlaylistPickerSheetContent({required this.tracks, this.playlistNamePrefill});
 
   @override
   ConsumerState<_PlaylistPickerSheetContent> createState() =>
@@ -130,7 +132,7 @@ class _PlaylistPickerSheetContentState
             leading: const Icon(Icons.add_circle_outline),
             title: Text(context.l10n.collectionCreatePlaylist),
             onTap: () async {
-              final name = await _promptPlaylistName(context);
+              final name = await _promptPlaylistName(context, widget.playlistNamePrefill);
               if (name == null || name.trim().isEmpty || !context.mounted) {
                 return;
               }
@@ -221,8 +223,8 @@ class _PlaylistPickerSheetContentState
   }
 }
 
-Future<String?> _promptPlaylistName(BuildContext context) async {
-  final controller = TextEditingController();
+Future<String?> _promptPlaylistName(BuildContext context, String? playlistNamePrefill) async {
+  final controller = TextEditingController(text: playlistNamePrefill);
   final formKey = GlobalKey<FormState>();
 
   final result = await showDialog<String>(


### PR DESCRIPTION
Closes #222 

Summary of changes
- Passed the Spotify playlist name through to the playlist picker sheet as a prefill
- When you hit "Create Playlist" from a Spotify playlist's add-to-playlist flow, the name field now comes pre-filled with the playlist name instead of being blank

Pretty small change but saves a bit of friction when importing playlists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Playlist name input now pre-fills contextually when creating a new playlist during track addition, streamlining the creation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->