### PR TITLE
 docs: Add SpotiFLAC Python Module to Other Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Want to create your own extension? Check out the [Extension Development Guide](h
 ### [SpotiFLAC (Desktop)](https://github.com/afkarxyz/SpotiFLAC)
 Download music in true lossless FLAC from Tidal, Qobuz & Amazon Music for Windows, macOS & Linux
 
+### [SpotiFLAC (Python Module)](https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version)
+SpotiFLAC Python library for SpotiFLAC integration — maintained by [@ShuShuzinhuu](https://github.com/ShuShuzinhuu)
+
 ## FAQ
 
 **Q: Why does the Store tab ask me to enter a URL?**  


### PR DESCRIPTION
Hi @zarzet!

I created a version of SpotiFLAC for Python. Great for including in projects, especially for beginners.

**Freatures:**
- Download Spotify tracks in FLAC from Tidal, Qobuz & Amazon Music
- Support for single tracks, albums, and playlists
- CLI suport
- It works on any device that has Python

**Repository:** https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version

I already mentioned your original project in my module's README file. Would you mind adding a link to the Python version in your README?

Thank you, your project has greatly encouraged me, and I want to provide support for the Python version of this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about SpotiFLAC Python module under "Other projects," including a repository link and attribution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->