### PR TITLE
fix: map missing Crowdin locale variants

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,6 +6,7 @@ files:
         # Short codes for single-variant languages
         de: de
         es: es
+        es-ES: es_ES
         fr: fr
         hi: hi
         id: id
@@ -13,7 +14,11 @@ files:
         ko: ko
         nl: nl
         pt: pt
+        pt-PT: pt_PT
         ru: ru
+        tr: tr
+        uk: uk
+        zh: zh
         # Full codes for Chinese variants
         zh-CN: zh_CN
         zh-TW: zh_TW


### PR DESCRIPTION
## Summary
- add Crowdin locale mappings for `tr`, `uk`, `zh`, `es-ES`, and `pt-PT`
- align GitHub sync config with the locale ARB files already present on `main`
- fix cases where Crowdin reads generic `es`/`pt` files instead of the populated regional variants

## Why
Crowdin on `main` already has locale files such as `app_tr.arb` and `app_uk.arb`, but `crowdin.yml` does not map those locales. Spanish and Portuguese also need regional mappings so Crowdin can target `app_es_ES.arb` and `app_pt_PT.arb` correctly.
