### PR TITLE
feat(track-options): add "Go to Album" option to track context menu

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4723,6 +4723,12 @@ abstract class AppLocalizations {
   /// **'Remove from Wishlist'**
   String get trackOptionRemoveFromWishlist;
 
+  /// Bottom sheet action label - navigate to the track's album page
+  ///
+  /// In en, this message translates to:
+  /// **'Go to Album'**
+  String get trackOptionGoToAlbum;
+
   /// Action label - add artist to favorite artists
   ///
   /// In en, this message translates to:
@@ -6316,6 +6322,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Looking up artist...'**
   String get clickableLookingUpArtist;
+
+  /// Snackbar shown while album metadata is being resolved
+  ///
+  /// In en, this message translates to:
+  /// **'Looking up album...'**
+  String get clickableLookingUpAlbum;
 
   /// Snackbar shown when clickable metadata cannot open a destination
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2720,6 +2720,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Von der Wunschliste entfernen';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3757,6 +3760,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3728,6 +3731,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3722,6 +3725,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2691,6 +2691,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3726,6 +3729,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3723,6 +3726,9 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2697,6 +2697,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3714,6 +3717,9 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2675,6 +2675,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'ウィッシュから削除';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3710,6 +3713,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2668,6 +2668,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3703,6 +3706,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3723,6 +3726,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3722,6 +3725,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2742,6 +2742,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Удалить из списка желаний';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3782,6 +3785,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2714,6 +2714,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3749,6 +3752,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2731,6 +2731,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Видалити зі списку бажань';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3782,6 +3785,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trackOptionRemoveFromWishlist => 'Remove from Wishlist';
 
   @override
+  String get trackOptionGoToAlbum => 'Go to Album';
+
+  @override
   String get artistOptionAddToFavorites => 'Add to Favorite Artists';
 
   @override
@@ -3722,6 +3725,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get clickableLookingUpArtist => 'Looking up artist...';
+
+  @override
+  String get clickableLookingUpAlbum => 'Looking up album...';
 
   @override
   String clickableInformationUnavailable(String type) {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -3575,6 +3575,10 @@
   "@trackOptionRemoveFromWishlist": {
     "description": "Bottom sheet action label - remove track from wishlist"
   },
+  "trackOptionGoToAlbum": "Go to Album",
+  "@trackOptionGoToAlbum": {
+    "description": "Bottom sheet action label - navigate to the track's album page"
+  },
   "artistOptionAddToFavorites": "Add to Favorite Artists",
   "@artistOptionAddToFavorites": {
     "description": "Action label - add artist to favorite artists"
@@ -4884,6 +4888,10 @@
   "clickableLookingUpArtist": "Looking up artist...",
   "@clickableLookingUpArtist": {
     "description": "Snackbar shown while clickable artist metadata is being resolved"
+  },
+  "clickableLookingUpAlbum": "Looking up album...",
+  "@clickableLookingUpAlbum": {
+    "description": "Snackbar shown while album metadata is being resolved"
   },
   "clickableInformationUnavailable": "{type} information not available",
   "@clickableInformationUnavailable": {

--- a/lib/utils/clickable_metadata.dart
+++ b/lib/utils/clickable_metadata.dart
@@ -230,7 +230,7 @@ Future<void> navigateToAlbum(
     return;
   }
 
-  _showLoadingSnackBar(context, 'Looking up album...');
+  _showLoadingSnackBar(context, context.l10n.clickableLookingUpAlbum);
   try {
     final query = artistName != null && artistName.isNotEmpty
         ? '$albumName $artistName'
@@ -248,7 +248,7 @@ Future<void> navigateToAlbum(
 
     final albumList = searchResult?.items ?? const <Map<String, dynamic>>[];
     if (albumList.isEmpty) {
-      _showUnavailable(context, 'Album');
+      _showUnavailable(context, context.l10n.trackAlbum);
       return;
     }
 
@@ -272,7 +272,7 @@ Future<void> navigateToAlbum(
     );
 
     if (resolvedId.isEmpty) {
-      _showUnavailable(context, 'Album');
+      _showUnavailable(context, context.l10n.trackAlbum);
       return;
     }
 
@@ -288,7 +288,7 @@ Future<void> navigateToAlbum(
     _log.e('Failed to look up album "$albumName": $e', e);
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-    _showUnavailable(context, 'Album');
+    _showUnavailable(context, context.l10n.trackAlbum);
   }
 }
 

--- a/lib/widgets/track_collection_quick_actions.dart
+++ b/lib/widgets/track_collection_quick_actions.dart
@@ -222,6 +222,21 @@ class _TrackOptionsSheet extends ConsumerWidget {
                   showAddTrackToPlaylistSheet(context, ref, track);
                 },
               ),
+              _OptionTile(
+                icon: Icons.album_outlined,
+                title: context.l10n.trackOptionGoToAlbum,
+                onTap: () {
+                  Navigator.pop(context);
+                  navigateToAlbum(
+                    context,
+                    albumName: track.albumName,
+                    albumId: track.albumId,
+                    artistName: track.artistName,
+                    coverUrl: track.coverUrl,
+                    extensionId: track.source,
+                  );
+                },
+              ),
 
               const SizedBox(height: 16),
             ],


### PR DESCRIPTION
## Summary

- Adds a **"Go to Album"** action to the three-dot track options bottom sheet, consistent with the existing "Go to Artist" navigation pattern
- Uses the existing `navigateToAlbum()` function which handles both direct navigation (when `albumId` is available) and metadata lookup fallback
- Passes `track.source` as `extensionId` so extension-sourced tracks navigate to the correct `ExtensionAlbumScreen`
- Also fixes two previously hardcoded English strings (`"Looking up album..."` and `"Album"`) in `navigateToAlbum()` to use proper l10n keys (`clickableLookingUpAlbum` and `trackAlbum`)

Closes #334

## Test plan

- [ ] Open the three-dot menu on any track — "Go to Album" appears below "Add to Playlist"
- [ ] Tap "Go to Album" on a track with a known `albumId` — navigates directly to the album screen
- [ ] Tap "Go to Album" on a local track without an `albumId` — shows "Looking up album..." snackbar, then navigates or shows unavailable message
- [ ] Tap "Go to Album" on an extension-sourced track — opens `ExtensionAlbumScreen` correctly
- [ ] Run `flutter analyze` — no new errors

