### PR TITLE
feat(player): add in-app audio player replacing external player

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,86 @@
+name: Build Debug APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to build from"
+        required: false
+        default: "feat/in-app-player"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost /usr/share/swift /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.8"
+          cache-dependency-path: go_backend/go.sum
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Install Android NDK
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses || true
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager \
+            "ndk;29.0.14206865" "platforms;android-36" "build-tools;36.0.0"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/29.0.14206865" >> $GITHUB_ENV
+
+      - name: Install gomobile
+        run: |
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          gomobile init
+
+      - name: Build Go backend (Android AAR)
+        working-directory: go_backend
+        env:
+          CGO_ENABLED: 1
+        run: |
+          mkdir -p ../android/app/libs
+          gomobile bind -target=android -androidapi 24 -o ../android/app/libs/gobackend.aar .
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Get Flutter dependencies
+        run: flutter pub get
+
+      - name: Build debug APK (arm64)
+        run: flutter build apk --debug --target-platform android-arm64
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotiflac-debug-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk
+          retention-days: 7

--- a/lib/models/player_state.dart
+++ b/lib/models/player_state.dart
@@ -1,0 +1,82 @@
+import 'package:spotiflac_android/models/track.dart';
+
+enum PlayerLoopMode { off, one, all }
+
+class QueueTrack {
+  final String title;
+  final String artist;
+  final String album;
+  final String? coverUrl;
+  final String filePath;
+  final Track? track;
+
+  const QueueTrack({
+    required this.title,
+    required this.artist,
+    required this.album,
+    this.coverUrl,
+    required this.filePath,
+    this.track,
+  });
+
+  QueueTrack copyWith({String? filePath}) => QueueTrack(
+    title: title,
+    artist: artist,
+    album: album,
+    coverUrl: coverUrl,
+    filePath: filePath ?? this.filePath,
+    track: track,
+  );
+}
+
+class PlayerState {
+  final List<QueueTrack> queue;
+  final int currentIndex;
+  final bool isPlaying;
+  final bool isLoading;
+  final Duration position;
+  final Duration duration;
+  final PlayerLoopMode loopMode;
+  final String? error;
+
+  const PlayerState({
+    this.queue = const [],
+    this.currentIndex = 0,
+    this.isPlaying = false,
+    this.isLoading = false,
+    this.position = Duration.zero,
+    this.duration = Duration.zero,
+    this.loopMode = PlayerLoopMode.off,
+    this.error,
+  });
+
+  QueueTrack? get current =>
+      queue.isEmpty ? null : queue[currentIndex.clamp(0, queue.length - 1)];
+
+  bool get hasTrack => queue.isNotEmpty;
+  bool get hasPrevious => currentIndex > 0;
+  bool get hasNext => currentIndex < queue.length - 1;
+
+  PlayerState copyWith({
+    List<QueueTrack>? queue,
+    int? currentIndex,
+    bool? isPlaying,
+    bool? isLoading,
+    Duration? position,
+    Duration? duration,
+    PlayerLoopMode? loopMode,
+    String? error,
+    bool clearError = false,
+  }) {
+    return PlayerState(
+      queue: queue ?? this.queue,
+      currentIndex: currentIndex ?? this.currentIndex,
+      isPlaying: isPlaying ?? this.isPlaying,
+      isLoading: isLoading ?? this.isLoading,
+      position: position ?? this.position,
+      duration: duration ?? this.duration,
+      loopMode: loopMode ?? this.loopMode,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}

--- a/lib/providers/playback_provider.dart
+++ b/lib/providers/playback_provider.dart
@@ -1,8 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:spotiflac_android/models/track.dart';
-import 'package:spotiflac_android/providers/download_queue_provider.dart';
-import 'package:spotiflac_android/providers/local_library_provider.dart';
-import 'package:spotiflac_android/services/library_database.dart';
+import 'package:spotiflac_android/providers/player_provider.dart';
 import 'package:spotiflac_android/utils/file_access.dart';
 import 'package:spotiflac_android/utils/logger.dart';
 
@@ -19,7 +17,7 @@ class PlaybackController extends Notifier<PlaybackState> {
   Future<void> playLocalPath({
     required String path,
     required String title,
-    required String artist,
+    String artist = '',
     String album = '',
     String coverUrl = '',
     Track? track,
@@ -27,161 +25,22 @@ class PlaybackController extends Notifier<PlaybackState> {
     if (isCueVirtualPath(path)) {
       throw Exception(cueVirtualTrackRequiresSplitMessage);
     }
-    _log.d('Opening external player for "$title" by $artist: $path');
-    await openFile(path);
+    _log.d('Playing in-app: "$title" by $artist: $path');
+    await ref.read(playerProvider.notifier).playFromPath(
+      filePath: path,
+      title: title,
+      artist: artist,
+      album: album,
+      coverUrl: coverUrl.isNotEmpty ? coverUrl : null,
+      track: track,
+    );
   }
 
   Future<void> playTrackList(List<Track> tracks, {int startIndex = 0}) async {
     if (tracks.isEmpty) return;
-
-    final orderedTracks = _orderedTracksFromStartIndex(tracks, startIndex);
-    var skippedCueVirtualTrack = false;
-    for (final track in orderedTracks) {
-      final resolvedPath = await _resolveTrackPath(track);
-      if (resolvedPath == null) {
-        continue;
-      }
-      if (isCueVirtualPath(resolvedPath)) {
-        skippedCueVirtualTrack = true;
-        continue;
-      }
-
-      _log.d(
-        'Opening first available external track for list playback: '
-        '"${track.name}" by ${track.artistName} -> $resolvedPath',
-      );
-      await openFile(resolvedPath);
-      return;
-    }
-
-    if (skippedCueVirtualTrack) {
-      throw Exception(cueVirtualTrackRequiresSplitMessage);
-    }
-
-    throw Exception(
-      'No local audio file is available to open. Download the track first.',
-    );
-  }
-
-  List<Track> _orderedTracksFromStartIndex(List<Track> tracks, int startIndex) {
-    final safeStart = startIndex.clamp(0, tracks.length - 1);
-    if (safeStart == 0) {
-      return List<Track>.from(tracks, growable: false);
-    }
-
-    return <Track>[
-      ...tracks.sublist(safeStart),
-      ...tracks.sublist(0, safeStart),
-    ];
-  }
-
-  Future<String?> _resolveTrackPath(Track track) async {
-    final historyState = ref.read(downloadHistoryProvider);
-    final historyNotifier = ref.read(downloadHistoryProvider.notifier);
-
-    final localItem = await _findLocalLibraryItemForTrack(track);
-    if (localItem != null && await fileExists(localItem.filePath)) {
-      return localItem.filePath;
-    }
-
-    final historyItem = await _findDownloadHistoryItemForTrack(
-      track,
-      historyState,
-    );
-    if (historyItem != null) {
-      if (await fileExists(historyItem.filePath)) {
-        return historyItem.filePath;
-      }
-      historyNotifier.removeFromHistory(historyItem.id);
-    }
-
-    return null;
-  }
-
-  Future<LocalLibraryItem?> _findLocalLibraryItemForTrack(Track track) async {
-    final isLocalSource = (track.source ?? '').toLowerCase() == 'local';
-    if (isLocalSource) {
-      final byId = await ref
-          .read(localLibraryProvider.notifier)
-          .getById(track.id);
-      if (byId != null) return byId;
-    }
-
-    final isrc = track.isrc?.trim();
-    return ref
-        .read(localLibraryProvider.notifier)
-        .findExistingAsync(
-          isrc: isrc,
-          trackName: track.name,
-          artistName: track.artistName,
-        );
-  }
-
-  Future<DownloadHistoryItem?> _findDownloadHistoryItemForTrack(
-    Track track,
-    DownloadHistoryState historyState,
-  ) async {
-    final historyNotifier = ref.read(downloadHistoryProvider.notifier);
-    for (final candidateId in _spotifyIdLookupCandidates(track.id)) {
-      final bySpotifyId = historyState.getBySpotifyId(candidateId);
-      if (bySpotifyId != null) {
-        return bySpotifyId;
-      }
-      final bySpotifyIdAsync = await historyNotifier.getBySpotifyIdAsync(
-        candidateId,
-      );
-      if (bySpotifyIdAsync != null) {
-        return bySpotifyIdAsync;
-      }
-    }
-
-    final isrc = track.isrc?.trim();
-    if (isrc != null && isrc.isNotEmpty) {
-      final byIsrc = historyState.getByIsrc(isrc);
-      if (byIsrc != null) {
-        return byIsrc;
-      }
-      final byIsrcAsync = await historyNotifier.getByIsrcAsync(isrc);
-      if (byIsrcAsync != null) {
-        return byIsrcAsync;
-      }
-    }
-
-    return historyNotifier.findByTrackAndArtistAsync(
-      track.name,
-      track.artistName,
-    );
-  }
-
-  List<String> _spotifyIdLookupCandidates(String rawId) {
-    final trimmed = rawId.trim();
-    if (trimmed.isEmpty) {
-      return const [];
-    }
-
-    final candidates = <String>{trimmed};
-    final lowered = trimmed.toLowerCase();
-    if (lowered.startsWith('spotify:track:')) {
-      final compact = trimmed.split(':').last.trim();
-      if (compact.isNotEmpty) {
-        candidates.add(compact);
-      }
-    } else if (!trimmed.contains(':')) {
-      candidates.add('spotify:track:$trimmed');
-    }
-
-    final uri = Uri.tryParse(trimmed);
-    final segments = uri?.pathSegments ?? const <String>[];
-    final trackIndex = segments.indexOf('track');
-    if (trackIndex >= 0 && trackIndex + 1 < segments.length) {
-      final pathId = segments[trackIndex + 1].trim();
-      if (pathId.isNotEmpty) {
-        candidates.add(pathId);
-        candidates.add('spotify:track:$pathId');
-      }
-    }
-
-    return candidates.toList(growable: false);
+    await ref
+        .read(playerProvider.notifier)
+        .playTrackList(tracks, startIndex: startIndex);
   }
 }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart' as ja;
+import 'package:spotiflac_android/models/player_state.dart';
+import 'package:spotiflac_android/models/track.dart';
+import 'package:spotiflac_android/providers/download_queue_provider.dart';
+import 'package:spotiflac_android/providers/local_library_provider.dart';
+import 'package:spotiflac_android/utils/file_access.dart';
+import 'package:spotiflac_android/utils/logger.dart';
+
+final _log = AppLogger('PlayerProvider');
+
+class PlayerController extends Notifier<PlayerState> {
+  late ja.AudioPlayer _player;
+
+  @override
+  PlayerState build() {
+    _player = ja.AudioPlayer();
+    final sub1 = _player.playerStateStream.listen(_onPlayerState);
+    final sub2 = _player.positionStream.listen(_onPosition);
+    final sub3 = _player.durationStream.listen(_onDuration);
+    ref.onDispose(() {
+      sub1.cancel();
+      sub2.cancel();
+      sub3.cancel();
+      _player.dispose();
+    });
+    return const PlayerState();
+  }
+
+  void _onPlayerState(ja.PlayerState ps) {
+    final isLoading = ps.processingState == ja.ProcessingState.loading ||
+        ps.processingState == ja.ProcessingState.buffering;
+    state = state.copyWith(isPlaying: ps.playing, isLoading: isLoading);
+    if (ps.processingState == ja.ProcessingState.completed) {
+      _handleTrackCompleted();
+    }
+  }
+
+  void _onPosition(Duration pos) {
+    state = state.copyWith(position: pos);
+  }
+
+  void _onDuration(Duration? dur) {
+    if (dur != null) state = state.copyWith(duration: dur);
+  }
+
+  void _handleTrackCompleted() {
+    switch (state.loopMode) {
+      case PlayerLoopMode.one:
+        _player.seek(Duration.zero);
+        _player.play();
+      case PlayerLoopMode.all:
+        final nextIndex =
+            state.hasNext ? state.currentIndex + 1 : 0;
+        _loadQueueIndex(nextIndex);
+      case PlayerLoopMode.off:
+        if (state.hasNext) _loadQueueIndex(state.currentIndex + 1);
+    }
+  }
+
+  Future<void> playFromPath({
+    required String filePath,
+    required String title,
+    String artist = '',
+    String album = '',
+    String? coverUrl,
+    Track? track,
+  }) async {
+    final entry = QueueTrack(
+      filePath: filePath,
+      title: title,
+      artist: artist,
+      album: album,
+      coverUrl: coverUrl,
+      track: track,
+    );
+    state = state.copyWith(
+      queue: [entry],
+      currentIndex: 0,
+      position: Duration.zero,
+      duration: Duration.zero,
+      isLoading: true,
+      clearError: true,
+    );
+    await _loadFromPath(filePath);
+  }
+
+  Future<void> playTrackList(List<Track> tracks, {int startIndex = 0}) async {
+    if (tracks.isEmpty) return;
+    final safeStart = startIndex.clamp(0, tracks.length - 1);
+    final entries = tracks
+        .map(
+          (t) => QueueTrack(
+            filePath: '',
+            title: t.name,
+            artist: t.artistName,
+            album: t.albumName,
+            coverUrl: t.coverUrl,
+            track: t,
+          ),
+        )
+        .toList(growable: false);
+
+    state = state.copyWith(
+      queue: entries,
+      currentIndex: safeStart,
+      position: Duration.zero,
+      duration: Duration.zero,
+      isLoading: true,
+      clearError: true,
+    );
+    await _loadTrack(tracks[safeStart], safeStart);
+  }
+
+  Future<void> _loadQueueIndex(int index) async {
+    if (index < 0 || index >= state.queue.length) return;
+    final entry = state.queue[index];
+    state = state.copyWith(
+      currentIndex: index,
+      position: Duration.zero,
+      duration: Duration.zero,
+      isLoading: true,
+    );
+    if (entry.filePath.isNotEmpty) {
+      await _loadFromPath(entry.filePath);
+    } else if (entry.track != null) {
+      await _loadTrack(entry.track!, index);
+    }
+  }
+
+  Future<void> _loadTrack(Track track, int queueIndex) async {
+    final path = await _resolveTrackPath(track);
+    if (path == null) {
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Track not downloaded. Download it first.',
+      );
+      return;
+    }
+    // Cache resolved path back into queue entry
+    if (queueIndex < state.queue.length) {
+      final newQueue = List<QueueTrack>.from(state.queue);
+      newQueue[queueIndex] = newQueue[queueIndex].copyWith(filePath: path);
+      state = state.copyWith(queue: newQueue);
+    }
+    await _loadFromPath(path);
+  }
+
+  Future<void> _loadFromPath(String filePath) async {
+    try {
+      state = state.copyWith(isLoading: true, clearError: true);
+      final uri = filePath.startsWith('content://')
+          ? Uri.parse(filePath)
+          : Uri.file(filePath);
+      await _player.setAudioSource(ja.AudioSource.uri(uri));
+      await _player.play();
+    } catch (e) {
+      _log.e('Playback failed for path "$filePath": $e', e);
+      state = state.copyWith(isLoading: false, error: 'Playback failed: $e');
+    }
+  }
+
+  Future<void> togglePlayPause() async {
+    if (_player.playing) {
+      await _player.pause();
+    } else {
+      await _player.play();
+    }
+  }
+
+  Future<void> seek(Duration position) async {
+    await _player.seek(position);
+    state = state.copyWith(position: position);
+  }
+
+  Future<void> skipToNext() => _loadQueueIndex(
+    state.hasNext
+        ? state.currentIndex + 1
+        : (state.loopMode == PlayerLoopMode.all ? 0 : state.currentIndex),
+  );
+
+  Future<void> skipToPrevious() async {
+    if (state.position.inSeconds > 3) {
+      await seek(Duration.zero);
+      return;
+    }
+    if (state.hasPrevious) await _loadQueueIndex(state.currentIndex - 1);
+  }
+
+  void cycleLoopMode() {
+    state = state.copyWith(
+      loopMode: switch (state.loopMode) {
+        PlayerLoopMode.off => PlayerLoopMode.all,
+        PlayerLoopMode.all => PlayerLoopMode.one,
+        PlayerLoopMode.one => PlayerLoopMode.off,
+      },
+    );
+  }
+
+  Future<void> stop() async {
+    await _player.stop();
+    state = const PlayerState();
+  }
+
+  Future<String?> _resolveTrackPath(Track track) async {
+    final localNotifier = ref.read(localLibraryProvider.notifier);
+
+    if ((track.source ?? '').toLowerCase() == 'local') {
+      final byId = await localNotifier.getById(track.id);
+      if (byId != null && await fileExists(byId.filePath)) return byId.filePath;
+    }
+
+    final existing = await localNotifier.findExistingAsync(
+      isrc: track.isrc?.trim(),
+      trackName: track.name,
+      artistName: track.artistName,
+    );
+    if (existing != null && await fileExists(existing.filePath)) {
+      return existing.filePath;
+    }
+
+    final historyState = ref.read(downloadHistoryProvider);
+    final historyNotifier = ref.read(downloadHistoryProvider.notifier);
+
+    for (final candidateId in _idCandidates(track.id)) {
+      final item = historyState.getBySpotifyId(candidateId) ??
+          await historyNotifier.getBySpotifyIdAsync(candidateId);
+      if (item != null && await fileExists(item.filePath)) return item.filePath;
+    }
+
+    final isrc = track.isrc?.trim();
+    if (isrc != null && isrc.isNotEmpty) {
+      final item = historyState.getByIsrc(isrc) ??
+          await historyNotifier.getByIsrcAsync(isrc);
+      if (item != null && await fileExists(item.filePath)) return item.filePath;
+    }
+
+    final byMeta = await historyNotifier.findByTrackAndArtistAsync(
+      track.name,
+      track.artistName,
+    );
+    if (byMeta != null && await fileExists(byMeta.filePath)) {
+      return byMeta.filePath;
+    }
+
+    return null;
+  }
+
+  List<String> _idCandidates(String rawId) {
+    final trimmed = rawId.trim();
+    if (trimmed.isEmpty) return const [];
+    final candidates = <String>{trimmed};
+    if (trimmed.toLowerCase().startsWith('spotify:track:')) {
+      candidates.add(trimmed.split(':').last.trim());
+    } else if (!trimmed.contains(':')) {
+      candidates.add('spotify:track:$trimmed');
+    }
+    return candidates.toList(growable: false);
+  }
+}
+
+final playerProvider = NotifierProvider<PlayerController, PlayerState>(
+  PlayerController.new,
+);

--- a/lib/screens/main_shell.dart
+++ b/lib/screens/main_shell.dart
@@ -21,6 +21,7 @@ import 'package:spotiflac_android/services/notification_service.dart';
 import 'package:spotiflac_android/services/app_remote_config_service.dart';
 import 'package:spotiflac_android/services/update_checker.dart';
 import 'package:spotiflac_android/widgets/app_announcement_dialog.dart';
+import 'package:spotiflac_android/widgets/mini_player.dart';
 import 'package:spotiflac_android/widgets/update_dialog.dart';
 import 'package:spotiflac_android/widgets/animation_utils.dart';
 import 'package:spotiflac_android/utils/logger.dart';
@@ -570,20 +571,26 @@ class _MainShellState extends ConsumerState<MainShell>
             );
           },
         ),
-        bottomNavigationBar: NavigationBar(
-          selectedIndex: _currentIndex.clamp(0, maxIndex),
-          onDestinationSelected: _onNavTap,
-          animationDuration: const Duration(milliseconds: 500),
-          backgroundColor: Theme.of(context).brightness == Brightness.dark
-              ? Color.alphaBlend(
-                  Colors.white.withValues(alpha: 0.05),
-                  Theme.of(context).colorScheme.surface,
-                )
-              : Color.alphaBlend(
-                  Colors.black.withValues(alpha: 0.03),
-                  Theme.of(context).colorScheme.surface,
-                ),
-          destinations: destinations,
+        bottomNavigationBar: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const MiniPlayer(),
+            NavigationBar(
+              selectedIndex: _currentIndex.clamp(0, maxIndex),
+              onDestinationSelected: _onNavTap,
+              animationDuration: const Duration(milliseconds: 500),
+              backgroundColor: Theme.of(context).brightness == Brightness.dark
+                  ? Color.alphaBlend(
+                      Colors.white.withValues(alpha: 0.05),
+                      Theme.of(context).colorScheme.surface,
+                    )
+                  : Color.alphaBlend(
+                      Colors.black.withValues(alpha: 0.03),
+                      Theme.of(context).colorScheme.surface,
+                    ),
+              destinations: destinations,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -1,0 +1,280 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotiflac_android/models/player_state.dart';
+import 'package:spotiflac_android/providers/player_provider.dart';
+import 'package:spotiflac_android/services/cover_cache_manager.dart';
+
+class PlayerScreen extends ConsumerWidget {
+  const PlayerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final playerState = ref.watch(playerProvider);
+    final current = playerState.current;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.keyboard_arrow_down),
+          iconSize: 32,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text(
+          current?.album ?? '',
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: Column(
+            children: [
+              const SizedBox(height: 16),
+              _AlbumArtwork(coverUrl: current?.coverUrl),
+              const SizedBox(height: 32),
+              _TrackInfo(current: current, colorScheme: colorScheme),
+              const SizedBox(height: 24),
+              _SeekBar(playerState: playerState, colorScheme: colorScheme),
+              const SizedBox(height: 24),
+              _Controls(playerState: playerState),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AlbumArtwork extends StatelessWidget {
+  final String? coverUrl;
+  const _AlbumArtwork({this.coverUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final size = MediaQuery.of(context).size.width - 56;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: coverUrl != null && coverUrl!.isNotEmpty
+          ? CachedNetworkImage(
+              imageUrl: coverUrl!,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+              memCacheWidth: (size * MediaQuery.of(context).devicePixelRatio).toInt(),
+              cacheManager: CoverCacheManager.instance,
+              errorWidget: (context, url, error) => _placeholder(colorScheme, size),
+            )
+          : _placeholder(colorScheme, size),
+    );
+  }
+
+  Widget _placeholder(ColorScheme colorScheme, double size) => Container(
+    width: size,
+    height: size,
+    color: colorScheme.surfaceContainerHighest,
+    child: Icon(
+      Icons.music_note,
+      color: colorScheme.onSurfaceVariant,
+      size: size * 0.4,
+    ),
+  );
+}
+
+class _TrackInfo extends StatelessWidget {
+  final QueueTrack? current;
+  final ColorScheme colorScheme;
+  const _TrackInfo({required this.current, required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                current?.title ?? '',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                current?.artist ?? '',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SeekBar extends ConsumerStatefulWidget {
+  final PlayerState playerState;
+  final ColorScheme colorScheme;
+  const _SeekBar({required this.playerState, required this.colorScheme});
+
+  @override
+  ConsumerState<_SeekBar> createState() => _SeekBarState();
+}
+
+class _SeekBarState extends ConsumerState<_SeekBar> {
+  double? _draggingValue;
+
+  String _format(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final total = widget.playerState.duration.inMilliseconds.toDouble();
+    final current = widget.playerState.position.inMilliseconds.toDouble();
+    final sliderValue = _draggingValue ?? (total > 0 ? (current / total).clamp(0.0, 1.0) : 0.0);
+
+    return Column(
+      children: [
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 3,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+          ),
+          child: Slider(
+            value: sliderValue,
+            onChanged: (v) => setState(() => _draggingValue = v),
+            onChangeEnd: (v) {
+              final seekMs = (v * total).round();
+              ref.read(playerProvider.notifier).seek(
+                Duration(milliseconds: seekMs),
+              );
+              setState(() => _draggingValue = null);
+            },
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _format(widget.playerState.position),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: widget.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              Text(
+                _format(widget.playerState.duration),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: widget.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Controls extends ConsumerWidget {
+  final PlayerState playerState;
+  const _Controls({required this.playerState});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final controller = ref.read(playerProvider.notifier);
+
+    final loopIcon = switch (playerState.loopMode) {
+      PlayerLoopMode.off => Icons.repeat,
+      PlayerLoopMode.all => Icons.repeat,
+      PlayerLoopMode.one => Icons.repeat_one,
+    };
+    final loopColor = playerState.loopMode == PlayerLoopMode.off
+        ? colorScheme.onSurfaceVariant
+        : colorScheme.primary;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        IconButton(
+          icon: Icon(loopIcon, color: loopColor),
+          iconSize: 24,
+          onPressed: controller.cycleLoopMode,
+          tooltip: 'Repeat',
+        ),
+        IconButton(
+          icon: Icon(Icons.skip_previous, color: colorScheme.onSurface),
+          iconSize: 36,
+          onPressed: controller.skipToPrevious,
+        ),
+        _PlayPauseButton(playerState: playerState),
+        IconButton(
+          icon: Icon(Icons.skip_next, color: colorScheme.onSurface),
+          iconSize: 36,
+          onPressed: controller.skipToNext,
+        ),
+        // Placeholder so repeat icon has a symmetric counterpart
+        const SizedBox(width: 48),
+      ],
+    );
+  }
+}
+
+class _PlayPauseButton extends ConsumerWidget {
+  final PlayerState playerState;
+  const _PlayPauseButton({required this.playerState});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      width: 64,
+      height: 64,
+      decoration: BoxDecoration(
+        color: colorScheme.primary,
+        shape: BoxShape.circle,
+      ),
+      child: playerState.isLoading
+          ? Padding(
+              padding: const EdgeInsets.all(18),
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: colorScheme.onPrimary,
+              ),
+            )
+          : IconButton(
+              icon: Icon(
+                playerState.isPlaying ? Icons.pause : Icons.play_arrow,
+                color: colorScheme.onPrimary,
+              ),
+              iconSize: 32,
+              onPressed: () =>
+                  ref.read(playerProvider.notifier).togglePlayPause(),
+            ),
+    );
+  }
+}

--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -1,0 +1,193 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotiflac_android/models/player_state.dart';
+import 'package:spotiflac_android/providers/player_provider.dart';
+import 'package:spotiflac_android/screens/player_screen.dart';
+import 'package:spotiflac_android/services/cover_cache_manager.dart';
+
+class MiniPlayer extends ConsumerWidget {
+  const MiniPlayer({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final playerState = ref.watch(playerProvider);
+    final current = playerState.current;
+    if (current == null) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final totalSeconds = playerState.duration.inSeconds;
+    final progress = totalSeconds > 0
+        ? (playerState.position.inSeconds / totalSeconds).clamp(0.0, 1.0)
+        : 0.0;
+
+    return Material(
+      elevation: 4,
+      color: colorScheme.surfaceContainerHigh,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => Navigator.of(context, rootNavigator: true).push(
+          PageRouteBuilder<void>(
+            pageBuilder: (context, animation, secondaryAnimation) => const PlayerScreen(),
+            transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+                SlideTransition(
+              position: Tween<Offset>(
+                begin: const Offset(0, 1),
+                end: Offset.zero,
+              ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic)),
+              child: child,
+            ),
+            transitionDuration: const Duration(milliseconds: 300),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            LinearProgressIndicator(
+              value: progress,
+              minHeight: 2,
+              backgroundColor: colorScheme.surfaceContainerHighest,
+              valueColor: AlwaysStoppedAnimation<Color>(colorScheme.primary),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Row(
+                children: [
+                  _AlbumArt(coverUrl: current.coverUrl),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          current.title,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (current.artist.isNotEmpty)
+                          Text(
+                            current.artist,
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: colorScheme.onSurfaceVariant),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                      ],
+                    ),
+                  ),
+                  _PrevButton(playerState: playerState),
+                  _PlayPauseButton(playerState: playerState),
+                  _NextButton(playerState: playerState),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AlbumArt extends StatelessWidget {
+  final String? coverUrl;
+  const _AlbumArt({this.coverUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(6),
+      child: coverUrl != null && coverUrl!.isNotEmpty
+          ? CachedNetworkImage(
+              imageUrl: coverUrl!,
+              width: 44,
+              height: 44,
+              fit: BoxFit.cover,
+              memCacheWidth: 88,
+              cacheManager: CoverCacheManager.instance,
+              errorWidget: (context, url, error) => _placeholder(colorScheme),
+            )
+          : _placeholder(colorScheme),
+    );
+  }
+
+  Widget _placeholder(ColorScheme colorScheme) => Container(
+    width: 44,
+    height: 44,
+    color: colorScheme.surfaceContainerHighest,
+    child: Icon(Icons.music_note, color: colorScheme.onSurfaceVariant, size: 20),
+  );
+}
+
+class _PlayPauseButton extends ConsumerWidget {
+  final PlayerState playerState;
+  const _PlayPauseButton({required this.playerState});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    if (playerState.isLoading) {
+      return SizedBox(
+        width: 36,
+        height: 36,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: colorScheme.primary,
+          ),
+        ),
+      );
+    }
+    return IconButton(
+      icon: Icon(
+        playerState.isPlaying ? Icons.pause : Icons.play_arrow,
+        color: colorScheme.onSurface,
+      ),
+      onPressed: () => ref.read(playerProvider.notifier).togglePlayPause(),
+      iconSize: 28,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+    );
+  }
+}
+
+class _PrevButton extends ConsumerWidget {
+  final PlayerState playerState;
+  const _PrevButton({required this.playerState});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      icon: Icon(
+        Icons.skip_previous,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+      onPressed: () => ref.read(playerProvider.notifier).skipToPrevious(),
+      iconSize: 24,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+    );
+  }
+}
+
+class _NextButton extends ConsumerWidget {
+  final PlayerState playerState;
+  const _NextButton({required this.playerState});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      icon: Icon(
+        Icons.skip_next,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+      onPressed: () => ref.read(playerProvider.notifier).skipToNext(),
+      iconSize: 24,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.25"
   boolean_selector:
     dependency: transitive
     description:
@@ -149,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -621,6 +629,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -637,6 +653,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.11.2"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: f978d5b4ccea08f267dae0232ec5405c1b05d3f3cd63f82097ea46c015d5c09e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.46"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "2532c8d6702528824445921c5ff10548b518b13f808c2e34c2fd54793b999a6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:
@@ -689,18 +729,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1246,26 +1286,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,9 @@ dependencies:
   ffmpeg_kit_flutter_new_full: ^2.0.0
   open_filex: ^4.7.0
 
+  # In-app audio playback
+  just_audio: ^0.9.40
+
   # Notifications
   flutter_local_notifications: 21.0.0
 


### PR DESCRIPTION
## Summary

Replaces the current behavior (tapping play opens the system's external audio player via `Intent.ACTION_VIEW`) with a fully integrated in-app audio player.

- **`just_audio`** (ExoPlayer-backed) handles actual audio decoding — supports FLAC, MP3, M4A, OGG, WAV, AAC, and SAF `content://` URIs natively on Android
- **`MiniPlayer`** bar slides in above the bottom nav when a track is playing, showing album art, title, artist, a thin progress indicator, and prev / play-pause / next controls
- **`PlayerScreen`** (full-screen slide-up) with large album art, an interactive seek bar, skip controls and a cycling repeat mode (off → all → one)
- **`PlayerController`** (Riverpod `Notifier`) owns the `AudioPlayer` lifecycle, resolves track file paths lazily using the existing `localLibraryProvider` + `downloadHistoryProvider` lookup chain, and auto-advances the queue on track completion
- **`PlaybackController`** now delegates `playLocalPath` and `playTrackList` to `PlayerController` — all existing call-sites across `queue_tab`, `album_screen`, `artist_screen`, `playlist_screen`, etc. work unchanged
- Queue support: playing an album/playlist stores the full track list; skip prev/next navigates within it with lazy path resolution

## Architecture

```
UI call-sites (unchanged)
    └── PlaybackController.playLocalPath / playTrackList
            └── PlayerController (just_audio)
                    ├── MiniPlayer  ← always visible above nav bar
                    └── PlayerScreen ← opened on tap
```

## Test plan

- [ ] Tap play on a downloaded track in the Library tab → audio plays in-app, MiniPlayer appears
- [ ] Tap play on an album → full queue is loaded, skip next/prev navigates between tracks
- [ ] Tap MiniPlayer → PlayerScreen slides up with seek bar and controls
- [ ] Seek bar drag → playback jumps to correct position
- [ ] Repeat off → all → one → off cycle works correctly
- [ ] Tapping play on a track not yet downloaded → shows error state in MiniPlayer
- [ ] SAF-mode (content:// paths) → audio plays correctly
- [ ] `flutter analyze` → no issues