### PR TITLE
fix(ui): use State's context instead of stale parameter in CSV import

### DIFF
--- a/lib/screens/home_tab.dart
+++ b/lib/screens/home_tab.dart
@@ -966,8 +966,7 @@ class _HomeTabState extends ConsumerState<HomeTab>
 
         if (!mounted) return;
 
-        // ignore: use_build_context_synchronously
-        final l10n = context.l10n;
+        final l10n = this.context.l10n;
 
         final options = await showDialog<_CsvImportOptions>(
           context: this.context,


### PR DESCRIPTION
_importCsv guards every other post-await BuildContext use with the State's own `mounted`/`this.context`, but one spot read the l10n strings off the function's `context` parameter instead, requiring a `// ignore: use_build_context_synchronously` to silence the analyzer. Switching to `this.context` matches the surrounding guard and lets the lint verify the usage on its own, so the suppression is no longer needed.