### PR TITLE
refactor(download): extract audio format helpers out of download_queue_provider

### DIFF
--- a/lib/providers/download_queue_provider.dart
+++ b/lib/providers/download_queue_provider.dart
@@ -18,6 +18,7 @@ import 'package:spotiflac_android/services/ffmpeg_service.dart';
 import 'package:spotiflac_android/services/notification_service.dart';
 import 'package:spotiflac_android/services/history_database.dart';
 import 'package:spotiflac_android/utils/logger.dart' hide log;
+import 'package:spotiflac_android/utils/audio_format_utils.dart';
 import 'package:spotiflac_android/utils/file_access.dart';
 import 'package:spotiflac_android/utils/string_utils.dart';
 import 'package:spotiflac_android/utils/artist_utils.dart';
@@ -35,152 +36,6 @@ final _trimDotsAndSpacesRegex = RegExp(r'^[. ]+|[. ]+$');
 final _trimUnderscoresAndSpacesRegex = RegExp(r'^[_ ]+|[_ ]+$');
 final _multiWhitespaceRegex = RegExp(r'\s+');
 final _multiUnderscoreRegex = RegExp(r'_+');
-
-int? _readPositiveBitrateKbps(dynamic value) {
-  final parsed = readPositiveInt(value);
-  if (parsed == null) return null;
-  final kbps = parsed >= 10000 ? (parsed / 1000).round() : parsed;
-  return kbps >= 16 ? kbps : null;
-}
-
-String? _audioFormatForPath(String? filePath, {String? fileName}) {
-  final candidates = <String>[?filePath, ?fileName];
-  for (final candidate in candidates) {
-    final lower = candidate.trim().toLowerCase();
-    if (lower.endsWith('.opus') || lower.endsWith('.ogg')) return 'OPUS';
-    if (lower.endsWith('.mp3')) return 'MP3';
-    if (lower.endsWith('.aac')) return 'AAC';
-    if (lower.endsWith('.m4a') || lower.endsWith('.mp4')) return 'M4A';
-  }
-  return null;
-}
-
-String? _nonPlaceholderQuality(String? quality) {
-  final normalized = normalizeOptionalString(quality);
-  if (normalized == null || isPlaceholderQualityLabel(normalized)) {
-    return null;
-  }
-  final bitrateMatch = RegExp(
-    r'\b(\d+)\s*kbps\b',
-    caseSensitive: false,
-  ).firstMatch(normalized);
-  if (bitrateMatch != null) {
-    final bitrate = int.tryParse(bitrateMatch.group(1) ?? '');
-    if (bitrate != null && bitrate < 16) return null;
-  }
-  final lower = normalized.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
-  const requestedLosslessLabels = {
-    'hi_res_lossless',
-    'hires_lossless',
-    'hi_res',
-    'hires',
-    'flac_best_available',
-  };
-  if (requestedLosslessLabels.contains(lower)) return null;
-  return normalized;
-}
-
-String? _normalizeAudioFormatValue(String? value) {
-  final normalized = normalizeOptionalString(
-    value,
-  )?.toLowerCase().replaceAll('-', '_');
-  return switch (normalized) {
-    'flac' => 'flac',
-    'alac' => 'alac',
-    'aac' || 'mp4a' => 'aac',
-    'eac3' || 'ec_3' => 'eac3',
-    'ac3' || 'ac_3' => 'ac3',
-    'ac4' || 'ac_4' => 'ac4',
-    'mp3' => 'mp3',
-    'opus' || 'ogg' => 'opus',
-    'm4a' || 'mp4' => 'm4a',
-    _ => null,
-  };
-}
-
-bool _isLossyAudioFormat(String? value) {
-  return const {
-    'aac',
-    'eac3',
-    'ac3',
-    'ac4',
-    'mp3',
-    'opus',
-    'm4a',
-  }.contains(_normalizeAudioFormatValue(value));
-}
-
-String _lossyFormatForSetting(String value) {
-  final normalized = value.trim().toLowerCase();
-  if (normalized.startsWith('opus')) return 'opus';
-  if (normalized.startsWith('aac') || normalized.startsWith('m4a')) {
-    return 'aac';
-  }
-  return 'mp3';
-}
-
-String _lossyExtensionForFormat(String format) {
-  return switch (format) {
-    'opus' => '.opus',
-    'aac' => '.m4a',
-    _ => '.mp3',
-  };
-}
-
-String _metadataFormatForLossyFormat(String format) {
-  return format == 'aac' ? 'm4a' : format;
-}
-
-String _displayFormatForLossyFormat(String format) {
-  return format == 'aac' ? 'AAC' : format.toUpperCase();
-}
-
-String? _resolveDisplayQuality({
-  required String? filePath,
-  String? fileName,
-  String? detectedFormat,
-  int? bitDepth,
-  int? sampleRate,
-  int? bitrateKbps,
-  String? storedQuality,
-}) {
-  final format =
-      _displayFormatForCodec(detectedFormat) ??
-      _audioFormatForPath(filePath, fileName: fileName);
-  if (format == 'OPUS' ||
-      format == 'MP3' ||
-      format == 'AAC' ||
-      format == 'EAC3' ||
-      format == 'AC3' ||
-      format == 'AC4' ||
-      (format == 'M4A' && (bitDepth == null || bitDepth <= 0))) {
-    return buildDisplayAudioQuality(bitrateKbps: bitrateKbps, format: format) ??
-        _nonPlaceholderQuality(storedQuality) ??
-        format;
-  }
-  return buildDisplayAudioQuality(
-    bitDepth: bitDepth,
-    sampleRate: sampleRate,
-    storedQuality: _nonPlaceholderQuality(storedQuality) ?? storedQuality,
-  );
-}
-
-String? _displayFormatForCodec(String? value) {
-  final normalized = normalizeOptionalString(
-    value,
-  )?.toLowerCase().replaceAll('-', '_');
-  return switch (normalized) {
-    'flac' => 'FLAC',
-    'alac' => 'ALAC',
-    'aac' || 'mp4a' => 'AAC',
-    'eac3' || 'ec_3' => 'EAC3',
-    'ac3' || 'ac_3' => 'AC3',
-    'ac4' || 'ac_4' => 'AC4',
-    'mp3' => 'MP3',
-    'opus' => 'OPUS',
-    _ => null,
-  };
-}
 
 /// log10 helper using dart:math's natural log.
 double _log10(num x) => log(x) / ln10;
@@ -843,14 +698,14 @@ class DownloadHistoryNotifier extends Notifier<DownloadHistoryState> {
 
       final bitDepth = readPositiveInt(result['bit_depth']);
       final sampleRate = readPositiveInt(result['sample_rate']);
-      final detectedFormat = _normalizeAudioFormatValue(
+      final detectedFormat = normalizeAudioFormatValue(
         result['audio_codec']?.toString() ?? result['format']?.toString(),
       );
-      final rawBitrateKbps = _readPositiveBitrateKbps(result['bitrate']);
-      final bitrateKbps = _isLossyAudioFormat(detectedFormat)
+      final rawBitrateKbps = readPositiveBitrateKbps(result['bitrate']);
+      final bitrateKbps = isLossyAudioFormat(detectedFormat)
           ? rawBitrateKbps
           : null;
-      final quality = _resolveDisplayQuality(
+      final quality = resolveDisplayQuality(
         filePath: filePath,
         detectedFormat: detectedFormat,
         bitDepth: bitDepth,
@@ -3391,7 +3246,7 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
     // the suffix), fall back to the actual audio codec reported by the backend
     // probe. This keeps any extension that returns a non-FLAC container (Opus,
     // MP3, AAC) from being mislabeled as FLAC.
-    final codec = _normalizeAudioFormatValue(
+    final codec = normalizeAudioFormatValue(
       result['audio_codec']?.toString() ??
           result['actual_audio_codec']?.toString() ??
           result['format']?.toString(),
@@ -6208,16 +6063,14 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
     final actualBitDepth = result['actual_bit_depth'] as int?;
     final actualSampleRate = result['actual_sample_rate'] as int?;
     final actualFormat =
-        _normalizeAudioFormatValue(
+        normalizeAudioFormatValue(
           result['audio_codec']?.toString() ?? result['format']?.toString(),
         ) ??
-        _normalizeAudioFormatValue(_audioFormatForPath(filePath));
-    final actualBitrate = _isLossyAudioFormat(actualFormat)
-        ? _readPositiveBitrateKbps(
-            result['bitrate'] ?? result['actual_bitrate'],
-          )
+        normalizeAudioFormatValue(audioFormatForPath(filePath));
+    final actualBitrate = isLossyAudioFormat(actualFormat)
+        ? readPositiveBitrateKbps(result['bitrate'] ?? result['actual_bitrate'])
         : null;
-    final resolvedQuality = _resolveDisplayQuality(
+    final resolvedQuality = resolveDisplayQuality(
       filePath: filePath,
       detectedFormat: actualFormat,
       bitDepth: actualBitDepth,
@@ -6332,12 +6185,12 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
     final resultSafFileName = result['file_name'] as String?;
     final lowerFilePath = filePath.toLowerCase();
     final historyFormat =
-        _normalizeAudioFormatValue(
+        normalizeAudioFormatValue(
           result['audio_codec']?.toString() ?? result['format']?.toString(),
         ) ??
-        _normalizeAudioFormatValue(_audioFormatForPath(filePath));
+        normalizeAudioFormatValue(audioFormatForPath(filePath));
     final isLossyOutput =
-        _isLossyAudioFormat(historyFormat) ||
+        isLossyAudioFormat(historyFormat) ||
         lowerFilePath.endsWith('.mp3') ||
         lowerFilePath.endsWith('.opus') ||
         lowerFilePath.endsWith('.ogg');
@@ -6539,9 +6392,9 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
     }
 
     final tidalHighFormat = settings.tidalHighFormat;
-    final format = _lossyFormatForSetting(tidalHighFormat);
-    final newExt = _lossyExtensionForFormat(format);
-    final displayFormat = _displayFormatForLossyFormat(format);
+    final format = lossyFormatForSetting(tidalHighFormat);
+    final newExt = lossyExtensionForFormat(format);
+    final displayFormat = displayFormatForLossyFormat(format);
     final bitrateDisplay = tidalHighFormat.contains('_')
         ? '${tidalHighFormat.split('_').last}kbps'
         : '320kbps';
@@ -6551,7 +6404,7 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
       await _embedMetadataToFile(
         convertedPath,
         track,
-        format: _metadataFormatForLossyFormat(format),
+        format: metadataFormatForLossyFormat(format),
         genre: result['genre'] as String?,
         label: result['label'] as String?,
         copyright: result['copyright'] as String?,
@@ -6637,11 +6490,11 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
     if (context.quality == 'HIGH' || context.outputExt != '.flac') {
       return filePath;
     }
-    final resultAudioFormat = _normalizeAudioFormatValue(
+    final resultAudioFormat = normalizeAudioFormatValue(
       result['audio_codec']?.toString() ??
           result['actual_audio_codec']?.toString(),
     );
-    if (_isLossyAudioFormat(resultAudioFormat)) {
+    if (isLossyAudioFormat(resultAudioFormat)) {
       _log.d(
         'Native-worker output is $resultAudioFormat; preserving native container.',
       );
@@ -7868,11 +7721,11 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
           result,
           filePath: filePath,
         );
-        final resultAudioFormat = _normalizeAudioFormatValue(
+        final resultAudioFormat = normalizeAudioFormatValue(
           result['audio_codec']?.toString() ??
               result['actual_audio_codec']?.toString(),
         );
-        final resultIsLossyAudio = _isLossyAudioFormat(resultAudioFormat);
+        final resultIsLossyAudio = isLossyAudioFormat(resultAudioFormat);
         final requiresContainerConversion =
             result['requires_container_conversion'] == true ||
             result['requiresContainerConversion'] == true ||
@@ -8086,8 +7939,8 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
                     progress: 0.95,
                   );
 
-                  final format = _lossyFormatForSetting(tidalHighFormat);
-                  final displayFormat = _displayFormatForLossyFormat(format);
+                  final format = lossyFormatForSetting(tidalHighFormat);
+                  final displayFormat = displayFormatForLossyFormat(format);
                   convertedPath = await FFmpegService.convertM4aToLossy(
                     tempPath,
                     format: format,
@@ -8113,14 +7966,14 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
                     await _embedMetadataToFile(
                       convertedPath,
                       trackToDownload,
-                      format: _metadataFormatForLossyFormat(format),
+                      format: metadataFormatForLossyFormat(format),
                       genre: backendGenre ?? genre,
                       label: backendLabel ?? label,
                       copyright: backendCopyright,
                       downloadService: item.service,
                     );
 
-                    final newExt = _lossyExtensionForFormat(format);
+                    final newExt = lossyExtensionForFormat(format);
                     final newFileName = '${safBaseName ?? 'track'}$newExt';
                     final newUri = await _writeTempToSaf(
                       treeUri: settings.downloadTreeUri,
@@ -8401,8 +8254,8 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
                   progress: 0.95,
                 );
 
-                final format = _lossyFormatForSetting(tidalHighFormat);
-                final displayFormat = _displayFormatForLossyFormat(format);
+                final format = lossyFormatForSetting(tidalHighFormat);
+                final displayFormat = displayFormatForLossyFormat(format);
                 final convertedPath = await FFmpegService.convertM4aToLossy(
                   currentFilePath,
                   format: format,
@@ -8434,7 +8287,7 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
                   await _embedMetadataToFile(
                     convertedPath,
                     trackToDownload,
-                    format: _metadataFormatForLossyFormat(format),
+                    format: metadataFormatForLossyFormat(format),
                     genre: backendGenre ?? genre,
                     label: backendLabel ?? label,
                     copyright: backendCopyright,
@@ -8958,12 +8811,12 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
           final backendBitDepth = result['actual_bit_depth'] as int?;
           final backendSampleRate = result['actual_sample_rate'] as int?;
           final backendFormat =
-              _normalizeAudioFormatValue(
+              normalizeAudioFormatValue(
                 result['audio_codec']?.toString() ??
                     result['format']?.toString(),
               ) ??
-              _normalizeAudioFormatValue(_audioFormatForPath(filePath));
-          final backendBitrateKbps = _readPositiveBitrateKbps(
+              normalizeAudioFormatValue(audioFormatForPath(filePath));
+          final backendBitrateKbps = readPositiveBitrateKbps(
             result['bitrate'] ?? result['actual_bitrate'],
           );
           final backendISRC = result['isrc'] as String?;
@@ -8987,7 +8840,7 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
           int? finalBitDepth = backendBitDepth;
           int? finalSampleRate = backendSampleRate;
           String? finalFormat = backendFormat;
-          int? finalBitrateKbps = _isLossyAudioFormat(finalFormat)
+          int? finalBitrateKbps = isLossyAudioFormat(finalFormat)
               ? backendBitrateKbps
               : null;
           final lowerFilePath = filePath.toLowerCase();
@@ -9018,22 +8871,22 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
                 if (probedSampleRate != null && probedSampleRate > 0) {
                   finalSampleRate = probedSampleRate;
                 }
-                final probedFormat = _normalizeAudioFormatValue(
+                final probedFormat = normalizeAudioFormatValue(
                   metadata['audio_codec']?.toString() ??
                       metadata['format']?.toString(),
                 );
                 if (probedFormat != null) {
                   finalFormat = probedFormat;
                 }
-                final probedBitrateKbps = _readPositiveBitrateKbps(
+                final probedBitrateKbps = readPositiveBitrateKbps(
                   metadata['bitrate'] ?? metadata['bit_rate'],
                 );
                 if (probedBitrateKbps != null &&
-                    _isLossyAudioFormat(finalFormat)) {
+                    isLossyAudioFormat(finalFormat)) {
                   finalBitrateKbps = probedBitrateKbps;
                 }
 
-                final resolvedQuality = _resolveDisplayQuality(
+                final resolvedQuality = resolveDisplayQuality(
                   filePath: filePath,
                   fileName: finalSafFileName,
                   detectedFormat: finalFormat,
@@ -9058,7 +8911,7 @@ class DownloadQueueNotifier extends Notifier<DownloadQueueState> {
           );
 
           final isLossyOutput =
-              _isLossyAudioFormat(finalFormat) ||
+              isLossyAudioFormat(finalFormat) ||
               lowerFilePath.endsWith('.mp3') ||
               lowerFilePath.endsWith('.opus') ||
               lowerFilePath.endsWith('.ogg');

--- a/lib/utils/audio_format_utils.dart
+++ b/lib/utils/audio_format_utils.dart
@@ -1,0 +1,166 @@
+import 'package:spotiflac_android/utils/int_utils.dart';
+import 'package:spotiflac_android/utils/string_utils.dart';
+
+/// Parses a bitrate value that may be expressed in bps or kbps, returning
+/// `null` for anything below a plausible lossy-audio floor.
+int? readPositiveBitrateKbps(dynamic value) {
+  final parsed = readPositiveInt(value);
+  if (parsed == null) return null;
+  final kbps = parsed >= 10000 ? (parsed / 1000).round() : parsed;
+  return kbps >= 16 ? kbps : null;
+}
+
+/// Guesses an audio format from a file path/name extension.
+String? audioFormatForPath(String? filePath, {String? fileName}) {
+  final candidates = <String>[?filePath, ?fileName];
+  for (final candidate in candidates) {
+    final lower = candidate.trim().toLowerCase();
+    if (lower.endsWith('.opus') || lower.endsWith('.ogg')) return 'OPUS';
+    if (lower.endsWith('.mp3')) return 'MP3';
+    if (lower.endsWith('.aac')) return 'AAC';
+    if (lower.endsWith('.m4a') || lower.endsWith('.mp4')) return 'M4A';
+  }
+  return null;
+}
+
+/// Returns [quality] unless it's a placeholder, an implausibly low bitrate,
+/// or a "requested lossless" label that doesn't describe an actual delivered
+/// quality (e.g. `HI_RES_LOSSLESS` before the real quality is known).
+String? nonPlaceholderQuality(String? quality) {
+  final normalized = normalizeOptionalString(quality);
+  if (normalized == null || isPlaceholderQualityLabel(normalized)) {
+    return null;
+  }
+  final bitrateMatch = RegExp(
+    r'\b(\d+)\s*kbps\b',
+    caseSensitive: false,
+  ).firstMatch(normalized);
+  if (bitrateMatch != null) {
+    final bitrate = int.tryParse(bitrateMatch.group(1) ?? '');
+    if (bitrate != null && bitrate < 16) return null;
+  }
+  final lower = normalized.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
+  const requestedLosslessLabels = {
+    'hi_res_lossless',
+    'hires_lossless',
+    'hi_res',
+    'hires',
+    'flac_best_available',
+  };
+  if (requestedLosslessLabels.contains(lower)) return null;
+  return normalized;
+}
+
+/// Normalizes a codec/format string to one of the lowercase canonical
+/// format keys used throughout the download/conversion pipeline.
+String? normalizeAudioFormatValue(String? value) {
+  final normalized = normalizeOptionalString(
+    value,
+  )?.toLowerCase().replaceAll('-', '_');
+  return switch (normalized) {
+    'flac' => 'flac',
+    'alac' => 'alac',
+    'aac' || 'mp4a' => 'aac',
+    'eac3' || 'ec_3' => 'eac3',
+    'ac3' || 'ac_3' => 'ac3',
+    'ac4' || 'ac_4' => 'ac4',
+    'mp3' => 'mp3',
+    'opus' || 'ogg' => 'opus',
+    'm4a' || 'mp4' => 'm4a',
+    _ => null,
+  };
+}
+
+/// Whether [value] normalizes to one of the lossy (bitrate-based) formats.
+bool isLossyAudioFormat(String? value) {
+  return const {
+    'aac',
+    'eac3',
+    'ac3',
+    'ac4',
+    'mp3',
+    'opus',
+    'm4a',
+  }.contains(normalizeAudioFormatValue(value));
+}
+
+/// Maps a free-form lossy format setting string to a canonical format key.
+String lossyFormatForSetting(String value) {
+  final normalized = value.trim().toLowerCase();
+  if (normalized.startsWith('opus')) return 'opus';
+  if (normalized.startsWith('aac') || normalized.startsWith('m4a')) {
+    return 'aac';
+  }
+  return 'mp3';
+}
+
+/// The file extension (with leading dot) for a canonical lossy format key.
+String lossyExtensionForFormat(String format) {
+  return switch (format) {
+    'opus' => '.opus',
+    'aac' => '.m4a',
+    _ => '.mp3',
+  };
+}
+
+/// The metadata-tag format name for a canonical lossy format key.
+String metadataFormatForLossyFormat(String format) {
+  return format == 'aac' ? 'm4a' : format;
+}
+
+/// The user-facing display label for a canonical lossy format key.
+String displayFormatForLossyFormat(String format) {
+  return format == 'aac' ? 'AAC' : format.toUpperCase();
+}
+
+/// The user-facing display format label for a codec/format string, or
+/// `null` if it doesn't map to a known display format.
+String? displayFormatForCodec(String? value) {
+  final normalized = normalizeOptionalString(
+    value,
+  )?.toLowerCase().replaceAll('-', '_');
+  return switch (normalized) {
+    'flac' => 'FLAC',
+    'alac' => 'ALAC',
+    'aac' || 'mp4a' => 'AAC',
+    'eac3' || 'ec_3' => 'EAC3',
+    'ac3' || 'ac_3' => 'AC3',
+    'ac4' || 'ac_4' => 'AC4',
+    'mp3' => 'MP3',
+    'opus' => 'OPUS',
+    _ => null,
+  };
+}
+
+/// Resolves the best user-facing quality/format label for a track from
+/// whatever combination of detected codec, bit depth/sample rate, bitrate,
+/// and previously stored quality string is available.
+String? resolveDisplayQuality({
+  required String? filePath,
+  String? fileName,
+  String? detectedFormat,
+  int? bitDepth,
+  int? sampleRate,
+  int? bitrateKbps,
+  String? storedQuality,
+}) {
+  final format =
+      displayFormatForCodec(detectedFormat) ??
+      audioFormatForPath(filePath, fileName: fileName);
+  if (format == 'OPUS' ||
+      format == 'MP3' ||
+      format == 'AAC' ||
+      format == 'EAC3' ||
+      format == 'AC3' ||
+      format == 'AC4' ||
+      (format == 'M4A' && (bitDepth == null || bitDepth <= 0))) {
+    return buildDisplayAudioQuality(bitrateKbps: bitrateKbps, format: format) ??
+        nonPlaceholderQuality(storedQuality) ??
+        format;
+  }
+  return buildDisplayAudioQuality(
+    bitDepth: bitDepth,
+    sampleRate: sampleRate,
+    storedQuality: nonPlaceholderQuality(storedQuality) ?? storedQuality,
+  );
+}

--- a/test/audio_format_utils_test.dart
+++ b/test/audio_format_utils_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spotiflac_android/utils/audio_format_utils.dart';
+
+void main() {
+  group('readPositiveBitrateKbps', () {
+    test('passes through plausible kbps values', () {
+      expect(readPositiveBitrateKbps(320), 320);
+    });
+
+    test('converts bps to kbps for large values', () {
+      expect(readPositiveBitrateKbps(320000), 320);
+    });
+
+    test('rejects implausibly low values', () {
+      expect(readPositiveBitrateKbps(8), isNull);
+    });
+
+    test('rejects non-numeric input', () {
+      expect(readPositiveBitrateKbps('not a number'), isNull);
+      expect(readPositiveBitrateKbps(null), isNull);
+    });
+  });
+
+  group('audioFormatForPath', () {
+    test('detects known extensions case-insensitively', () {
+      expect(audioFormatForPath('/music/song.OPUS'), 'OPUS');
+      expect(audioFormatForPath('/music/song.ogg'), 'OPUS');
+      expect(audioFormatForPath('/music/song.mp3'), 'MP3');
+      expect(audioFormatForPath('/music/song.aac'), 'AAC');
+      expect(audioFormatForPath('/music/song.m4a'), 'M4A');
+      expect(audioFormatForPath('/music/song.mp4'), 'M4A');
+    });
+
+    test('falls back to fileName when filePath does not match', () {
+      expect(
+        audioFormatForPath(null, fileName: 'track.mp3'),
+        'MP3',
+      );
+    });
+
+    test('returns null for unknown or missing extensions', () {
+      expect(audioFormatForPath('/music/song.flac'), isNull);
+      expect(audioFormatForPath(null), isNull);
+    });
+  });
+
+  group('nonPlaceholderQuality', () {
+    test('returns null for placeholder or empty quality', () {
+      expect(nonPlaceholderQuality(null), isNull);
+      expect(nonPlaceholderQuality('lossless'), isNull);
+    });
+
+    test('returns null for implausibly low bitrate labels', () {
+      expect(nonPlaceholderQuality('8 kbps'), isNull);
+    });
+
+    test('returns null for requested-lossless placeholder labels', () {
+      expect(nonPlaceholderQuality('Hi-Res Lossless'), isNull);
+      expect(nonPlaceholderQuality('HIRES'), isNull);
+    });
+
+    test('returns a real quality label unchanged', () {
+      expect(nonPlaceholderQuality('FLAC 1411kbps'), 'FLAC 1411kbps');
+    });
+  });
+
+  group('normalizeAudioFormatValue / isLossyAudioFormat', () {
+    test('normalizes known aliases to canonical keys', () {
+      expect(normalizeAudioFormatValue('MP4A'), 'aac');
+      expect(normalizeAudioFormatValue('EC-3'), 'eac3');
+      expect(normalizeAudioFormatValue('ogg'), 'opus');
+      expect(normalizeAudioFormatValue('mp4'), 'm4a');
+      expect(normalizeAudioFormatValue('unknown'), isNull);
+    });
+
+    test('classifies lossy vs lossless formats', () {
+      expect(isLossyAudioFormat('mp3'), isTrue);
+      expect(isLossyAudioFormat('m4a'), isTrue);
+      expect(isLossyAudioFormat('flac'), isFalse);
+      expect(isLossyAudioFormat('alac'), isFalse);
+      expect(isLossyAudioFormat(null), isFalse);
+    });
+  });
+
+  group('lossy format helpers', () {
+    test('lossyFormatForSetting maps free-form settings to canonical keys', () {
+      expect(lossyFormatForSetting('OPUS 256kbps'), 'opus');
+      expect(lossyFormatForSetting('AAC 256kbps'), 'aac');
+      expect(lossyFormatForSetting('M4A'), 'aac');
+      expect(lossyFormatForSetting('anything else'), 'mp3');
+    });
+
+    test('lossyExtensionForFormat returns the matching extension', () {
+      expect(lossyExtensionForFormat('opus'), '.opus');
+      expect(lossyExtensionForFormat('aac'), '.m4a');
+      expect(lossyExtensionForFormat('mp3'), '.mp3');
+    });
+
+    test('metadataFormatForLossyFormat renames aac to m4a for tagging', () {
+      expect(metadataFormatForLossyFormat('aac'), 'm4a');
+      expect(metadataFormatForLossyFormat('opus'), 'opus');
+    });
+
+    test('displayFormatForLossyFormat renders a user-facing label', () {
+      expect(displayFormatForLossyFormat('aac'), 'AAC');
+      expect(displayFormatForLossyFormat('opus'), 'OPUS');
+    });
+  });
+
+  group('displayFormatForCodec', () {
+    test('maps known codecs to display labels', () {
+      expect(displayFormatForCodec('flac'), 'FLAC');
+      expect(displayFormatForCodec('EC-3'), 'EAC3');
+      expect(displayFormatForCodec('unknown'), isNull);
+    });
+  });
+
+  group('resolveDisplayQuality', () {
+    test('prefers a bitrate label for lossy formats', () {
+      expect(
+        resolveDisplayQuality(
+          filePath: '/music/song.mp3',
+          bitrateKbps: 320,
+        ),
+        'MP3 320kbps',
+      );
+    });
+
+    test('falls back to the stored quality when bitrate is unavailable', () {
+      expect(
+        resolveDisplayQuality(
+          filePath: '/music/song.mp3',
+          storedQuality: 'MP3 CBR',
+        ),
+        'MP3 CBR',
+      );
+    });
+
+    test('falls back to bit depth/sample rate for hi-res containers', () {
+      expect(
+        resolveDisplayQuality(
+          filePath: '/music/song.flac',
+          detectedFormat: 'flac',
+          bitDepth: 24,
+          sampleRate: 96000,
+        ),
+        '24-bit/96kHz',
+      );
+    });
+
+    test('treats M4A with a real bit depth as a hi-res container, not lossy', () {
+      expect(
+        resolveDisplayQuality(
+          filePath: '/music/song.m4a',
+          bitDepth: 24,
+          sampleRate: 48000,
+        ),
+        '24-bit/48kHz',
+      );
+    });
+  });
+}


### PR DESCRIPTION
### What

First, small step toward the refactor proposed in #463 — extracts 11 pure, self-contained audio format/quality-label helpers out of `download_queue_provider.dart` into a new `lib/utils/audio_format_utils.dart`. No behavior change, same logic, just moved and made public (was private to that one file, so it had no direct test coverage before).

Deliberately scoped small to validate the approach before attempting anything larger on this file, per the discussion in #463.

### Why this chunk first

These functions were the most self-contained piece: no dependency on `Notifier` state, `ref`, or I/O — pure functions in, values out. Low risk, easy to review, easy to verify nothing changed.

### Included

- `lib/utils/audio_format_utils.dart` — the 11 extracted functions (format detection from path, lossy/lossless classification, display-quality resolution, etc.)
- `test/audio_format_utils_test.dart` — 22 new test cases covering them (previously untestable since they were private)
- `download_queue_provider.dart` — removed the 11 private definitions, added the import, renamed call sites to the public names. Diff is otherwise mechanical.

### Note for a possible follow-up

`track_metadata_screen.dart` has its own near-duplicate copies of a few of these (`_normalizeAudioFormatValue`, `_isBitrateFormatValue`, `_readPlausibleBitrateKbps`). I didn't consolidate them here because its quality-label helper (`_usableStoredQuality`) has a subtly different placeholder-filtering rule than `nonPlaceholderQuality` in this PR (it doesn't filter the "requested lossless" labels) — merging them without checking which behavior is actually correct could be a real change in behavior, not just a refactor. Flagging it rather than guessing.

### Verification

- `flutter analyze` — no issues
- `flutter test` — all new tests pass; the one pre-existing failure (`DownloadRequestPayload serializes all backend field names`) also fails on unmodified `main`, unrelated to this change
